### PR TITLE
feat: streamToCsv reply decorator

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Autotelic
+Copyright (c) 2022 Autotelic
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,41 @@
-# fastify-plugin-example
+# fastify-stream-to-csv
 
-Fastify plugin template.
+Stream CSVs from Fastify routes. Uses [fast-csv](https://c2fo.github.io/fast-csv/) for formatting.
+
+## Installation
+
+```
+npm i -S @autotelic/fastify-stream-to-csv
+```
+
+## Usage
+
+```js
+const { fastifyStreamToCsv } = require('@autotelic/fastify-stream-to-csv')
+
+const fastify = Fastify()
+
+fastify.register(fastifyStreamToCsv)
+
+fastify.get('/report', async function (req, reply) {
+  // create a readable stream
+  const readStream = Readable.from(Array.from(Array(100000).keys()))
+
+  // create a row formatter
+  const rowFormatter = num => {
+    return [`a${num}`, `b${num}`, `c${num}`]
+  }
+
+  // these are fast-csv format options
+  const csvOptions = {
+    delimiter: '\t',
+    headers: ['a', 'b', 'c']
+  }
+
+  // use reply decorator
+  reply.streamToCsv(readStream, rowFormatter, { csvOptions })
+}
+```
 
 ## Github Actions/Workflows
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ fastify.get('/report', async function (req, reply) {
   }
 
   // use reply decorator
-  reply.streamToCsv(readStream, rowFormatter, { csvOptions })
+  await reply
+    .header('Content-disposition', 'attachment; filename=basic-example.csv')
+    .streamToCsv(readStream, rowFormatter, { csvOptions })
 }
 ```
 

--- a/examples/basic/index.js
+++ b/examples/basic/index.js
@@ -21,7 +21,7 @@ module.exports = async function (fastify, options) {
     }
 
     // use reply decorator
-    reply
+    await reply
       .header('Content-disposition', 'attachment; filename=basic-example.csv')
       .streamToCsv(readStream, rowFormatter, { csvOptions })
   })

--- a/examples/basic/index.js
+++ b/examples/basic/index.js
@@ -1,0 +1,28 @@
+const { Readable } = require('stream')
+const { fastifyStreamToCsv } = require('../../')
+
+module.exports = async function (fastify, options) {
+
+  fastify.register(fastifyStreamToCsv)
+
+  fastify.get('/report', async function (req, reply) {
+    // create a readable stream
+    const readStream = Readable.from(Array.from(Array(100000).keys()))
+
+    // create a row formatter
+    const rowFormatter = num => {
+      return [`a${num}`, `b${num}`, `c${num}`]
+    }
+
+    // these are fast-csv format options
+    const csvOptions = {
+      delimiter: '\t',
+      headers: ['a', 'b', 'c']
+    }
+
+    // use reply decorator
+    reply
+      .header('Content-disposition', 'attachment; filename=basic-example.csv')
+      .streamToCsv(readStream, rowFormatter, { csvOptions })
+  })
+}

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "test": "c8 --100 ava",
     "lint": "standard",
     "fix": "standard --fix",
-    "validate": "npm run lint && npm run test",
-    "postinstall": "husky install"
+    "validate": "npm run lint && npm run test"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "fastify-plugin-template",
-  "version": "0.0.0",
-  "description": "Plugin for fastify",
+  "name": "@autotelic/fastify-stream-to-csv",
+  "version": "0.1.0",
+  "description": "Stream CSVs from Fastify routes",
   "main": "index.js",
   "directories": {
     "test": "test"
@@ -15,26 +15,29 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/autotelic/fastify-plugin-template.git"
+    "url": "git+https://github.com/autotelic/fastify-stream-to-csv.git"
   },
   "keywords": [],
-  "author": "Autotelic Development Ltd <info@autotelic.com>",
+  "author": "Autotelic Development Ltd <hello@autotelic.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/autotelic/fastify-plugin-template/issues"
+    "url": "https://github.com/autotelic/fastify-stream-to-csv/issues"
   },
-  "homepage": "https://github.com/autotelic/fastify-plugin-template#readme",
+  "homepage": "https://github.com/autotelic/fastify-stream-to-csv#readme",
   "dependencies": {
+    "@fast-csv/format": "^4.3.5",
     "fastify-plugin": "^3.0.0"
   },
   "devDependencies": {
     "ava": "^3.15.0",
     "c8": "^7.10.0",
+    "csv-parse": "^5.0.4",
     "fastify": "^3.0.0",
-    "fastify-cli": "^2.5.1",
+    "fastify-cli": "^2.15.0",
     "husky": "^7.0.4",
     "lint-staged": "^12.1.2",
-    "standard": "^16.0.3"
+    "standard": "^16.0.3",
+    "supertest": "^6.2.2"
   },
   "lint-staged": {
     "*.{js,jsx}": [

--- a/test.js
+++ b/test.js
@@ -1,3 +1,65 @@
 const test = require('ava')
+const Fastify = require('fastify')
+const supertest = require('supertest')
+const { Readable } = require('stream')
+const { parse } = require('csv-parse/sync')
 
-test('passes', (t) => t.pass())
+const { fastifyStreamToCsv } = require('./index')
+
+test('Namespace should exist:', async (t) => {
+  const fastify = Fastify()
+  t.teardown(() => fastify.close())
+
+  fastify.register(fastifyStreamToCsv)
+  await fastify.ready()
+
+  t.true(fastify.hasReplyDecorator('streamToCsv'), 'has streamToCsv reply decorator')
+})
+
+test('Should create a CSV file:', async (t) => {
+  const fastify = Fastify()
+  t.teardown(() => fastify.close())
+
+  fastify.register(fastifyStreamToCsv)
+
+  fastify.get('/', async function (req, reply) {
+    const readStream = Readable.from(Array.from(Array(1).keys()))
+
+    const rowFormatter = num => {
+      return [`a${num}`, `b${num}`, `c${num}`]
+    }
+
+    reply.streamToCsv(readStream, rowFormatter, {
+      csvOptions: {
+        headers: ['a', 'b', 'c']
+      }
+    })
+  })
+
+  await fastify.ready()
+
+  const response = await supertest(fastify.server)
+    .get('/')
+    .buffer()
+    .parse((res, callback) => {
+      res.setEncoding('binary')
+      res.data = ''
+      res.on('data', (chunk) => {
+        res.data += chunk
+      })
+      res.on('end', () => {
+        callback(null, Buffer.from(res.data, 'binary'))
+      })
+    })
+
+  t.is(response.statusCode, 200)
+  t.is(response.headers['content-type'], 'text/csv')
+  t.not(response.headers['content-length'], 0)
+
+  const csvResponse = parse(response.body)
+
+  t.deepEqual(csvResponse, [
+    [ 'a', 'b', 'c' ],
+    [ 'a0', 'b0', 'c0' ]
+  ])
+})


### PR DESCRIPTION
## Summary

- adds `streamToCsv` reply decorator for plugin

## Test Plan

Install [`fastify-cli`](https://github.com/fastify/fastify-cli#install) globally if you don't already have it.

- `npm install`
- `cd examples/basic`
- `fastify start -l info -w index.js`
- browse to http://localhost:3000/report
- `basic-example.csv` should be downloaded, contains 100000 rows

